### PR TITLE
Distinguish between template-haskell-2.10 changes and ghc-7.10 changes

### DIFF
--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -18,9 +18,12 @@ module Language.Haskell.TH.Lift
 import Data.PackedString (PackedString, packString, unpackPS)
 #endif /* MIN_VERSION_template_haskell(2,4,0) */
 
+#if __GLASGOW_HASKELL__ < 710
+import GHC.Exts (Int(..))
+#endif
+
 #if !(MIN_VERSION_template_haskell(2,10,0))
 import Data.Ratio (Ratio)
-import GHC.Exts (Int(..))
 #endif /* !(MIN_VERSION_template_haskell(2,10,0)) */
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
@@ -134,15 +137,15 @@ instance Lift PackedString where
 instance Lift NameFlavour where
   lift NameS = [| NameS |]
   lift (NameQ modnam) = [| NameQ modnam |]
-#if MIN_VERSION_template_haskell(2,10,0)
+#if __GLASGOW_HASKELL__ >= 710
   lift (NameU i) = [| NameU i |]
   lift (NameL i) = [| NameL i |]
-#else /* MIN_VERSION_template_haskell(2,10,0) */
+#else /* __GLASGOW_HASKELL__ < 710 */
   lift (NameU i) = [| case $( lift (I# i) ) of
                           I# i' -> NameU i' |]
   lift (NameL i) = [| case $( lift (I# i) ) of
                           I# i' -> NameL i' |]
-#endif /* MIN_VERSION_template_haskell(2,10,0) */
+#endif /* __GLASGOW_HASKELL__ < 710 */
   lift (NameG nameSpace pkgName modnam)
    = [| NameG nameSpace pkgName modnam |]
 


### PR DESCRIPTION
I've built this using ghc-7.10+th-2.10, ghc-7.8+th-2.9, and ghc-7.8+th-2.10.