### PR TITLE
Make th-lift handle empty and unboxed data types

### DIFF
--- a/t/Foo.hs
+++ b/t/Foo.hs
@@ -1,6 +1,13 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Foo where
+
+import GHC.Prim (Double#, Float#, Int#, Word#)
+#if MIN_VERSION_template_haskell(2,11,0)
+import GHC.Prim (Char#)
+#endif
 
 import Language.Haskell.TH.Lift
 
@@ -15,5 +22,20 @@ data (Eq a) => Foo a = Foo a Char | Bar a
 newtype Rec a = Rec { field :: a }
                 deriving Show
 
+data Empty a
+
+data Unboxed = Unboxed {
+-- Template Haskell couldn't handle unlifted chars on GHC < 8.0
+#if MIN_VERSION_template_haskell(2,11,0)
+  primChar   :: Char#,
+#endif
+  primDouble :: Double#,
+  primFloat  :: Float#,
+  primInt    :: Int#,
+  primWord   :: Word#
+  } deriving Show
+
 $(deriveLift ''Foo)
 $(deriveLift ''Rec)
+$(deriveLift ''Empty)
+$(deriveLift ''Unboxed)

--- a/t/Test.hs
+++ b/t/Test.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Main (main) where
 
@@ -8,3 +10,8 @@ main :: IO ()
 main = do print $( lift (Foo "str1" 'c') )
           print $( lift (Bar "str2") )
           print $( lift (Rec {field = 'a'}) )
+          print $( lift (Unboxed
+#if MIN_VERSION_template_haskell(2,11,0)
+                          'a'#
+#endif
+                          1.0## 1.0# 1# 1##) )

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -23,14 +23,15 @@ Library
   Exposed-modules: Language.Haskell.TH.Lift
   Extensions:      CPP, TemplateHaskell, MagicHash, TypeSynonymInstances, FlexibleInstances
   Hs-Source-Dirs:  src
-  Build-Depends:   base >= 3 && < 5
+  Build-Depends:   base >= 3 && < 5,
+                   ghc-prim
 
   ghc-options:     -Wall
   if impl(ghc < 6.12)
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.11
+    Build-Depends: template-haskell >= 2.4 && < 2.12
 
 Test-Suite test
   Type:             exitcode-stdio-1.0
@@ -39,9 +40,10 @@ Test-Suite test
   other-modules:    Foo
   ghc-options:      -Wall
   Build-Depends:    base >= 3 && < 5,
+                    ghc-prim,
                     th-lift
   if impl(ghc < 6.12)
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.11
+    Build-Depends: template-haskell >= 2.4 && < 2.12


### PR DESCRIPTION
`th-lift` will no longer crash when handling empty datatypes, or datatypes that contain `Addr#`, `Double#`, `Float#`, `Int#`, or `Word#` (or `Char#`, on GHC 8.0 and above) arguments. This fixes one part of #17.