### PR TITLE
Allow splicing of individual lift functions

### DIFF
--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -61,7 +61,14 @@ deriveLiftMany' :: [Info] -> Q [Dec]
 deriveLiftMany' = mapM deriveLiftOne
 
 -- | Generates a lambda expresson which behaves like 'lift' (without requiring
--- a 'Lift' instance).
+-- a 'Lift' instance). Example:
+--
+-- @
+-- newtype Fix f = In { out :: f (Fix f) }
+--
+-- instance Lift (f (Fix f)) => Lift (Fix f) where
+--   lift = $(makeLift ''Fix)
+-- @
 makeLift :: Name -> Q Exp
 makeLift = makeLift' <=< reify
 

--- a/t/Foo.hs
+++ b/t/Foo.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Foo where
 
 import GHC.Prim (Double#, Float#, Int#, Word#)
@@ -35,7 +38,12 @@ data Unboxed = Unboxed {
   primWord   :: Word#
   } deriving Show
 
+newtype Fix f = In { out :: f (Fix f) }
+deriving instance Show (f (Fix f)) => Show (Fix f)
+
 $(deriveLift ''Foo)
 $(deriveLift ''Rec)
 $(deriveLift ''Empty)
 $(deriveLift ''Unboxed)
+instance Lift (f (Fix f)) => Lift (Fix f) where
+  lift = $(makeLift ''Fix)

--- a/t/Test.hs
+++ b/t/Test.hs
@@ -15,3 +15,4 @@ main = do print $( lift (Foo "str1" 'c') )
                           'a'#
 #endif
                           1.0## 1.0# 1# 1##) )
+          print $( lift (In { out = Nothing }) )


### PR DESCRIPTION
There are some corner cases for datatypes which `th-lift` cannot derive, e.g., `newtype Fix f = In (f (Fix f))`, due to the complicated instance context that its `Lift` instance would require:

```haskell
instance Lift (f (Fix f)) => Lift (Fix f) where
    lift = ...
```

A relatively easy workaround is to allow the ability to splice in individual `lift` functions in addition to deriving the whole instance. With the addition of `makeLift`, the above instance could be derived without too much work:

```haskell
instance Lift (f (Fix f)) => Lift (Fix f) where
    lift = $(makeLift ''Fix)
```

This addresses the second part of #17.