### PR TITLE
Support deriving for data family instances

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+2015-11-09  Mathieu Boespflug <mboes@tweag.net>
+    * Support for constructor-less datatypes and unboxed arguments, matching
+	  the behavior of DeriveLift in GHC 8.0.
+	* Allow splicing individual lift functions via makeLift.
+	* Support for data families.
+
 2014-12-07  Mathieu Boespflug <mboes@tweag.net>
 
 	* Support GHC 7.9 and hopefully 7.10, thanks to Richard Eisenberg.

--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -37,22 +37,50 @@ import Data.Ratio (Ratio)
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Control.Monad ((<=<), zipWithM)
+import Data.List (foldl')
+#if MIN_VERSION_template_haskell(2,7,0)
+import Data.List (find)
+#endif /* !(MIN_VERSION_template_haskell(2,7,0)) */
 #if MIN_VERSION_template_haskell(2,9,0)
 import Data.Maybe (catMaybes)
 #endif /* MIN_VERSION_template_haskell(2,9,0) */
+#if MIN_VERSION_template_haskell(2,8,0) && __GLASGOW_HASKELL__ < 710
+import qualified Data.Set as Set (Set, empty, singleton, size, union, unions)
+#endif /* !(MIN_VERSION_template_haskell(2,8,0)) || __GLASGOW_HASKELL__ >= 710 */
 
 modName :: String
 modName = "Language.Haskell.TH.Lift"
 
--- | Derive Lift instances for the given datatype.
+-- | Derive 'Lift' instances for the given datatype.
+-- For plain datatypes, simply give the name of the type constructor
+-- (preceding the name with two single quotes):
+--
+-- @
+-- data Pair a = MkPair a a
+--
+-- $(deriveLift ''Pair)
+-- @
+--
+-- If using GHC 7.4 or later, you can also derive 'Lift' for data family instances.
+-- To do so, pass the name of a data family instance constructor
+-- (preceding the name with one single quote):
+--
+-- @
+-- data family PairFam a
+-- data instance PairFam a = IntPair Int Int
+--                         | OtherPair a a
+--
+-- $(deriveLift 'IntPair)
+-- -- Or, equivalently, $(deriveLift 'OtherPair)
+-- @
 deriveLift :: Name -> Q [Dec]
 deriveLift = deriveLift' <=< reify
 
--- | Derive Lift instances for many datatypes.
+-- | Derive 'Lift' instances for many datatypes.
 deriveLiftMany :: [Name] -> Q [Dec]
 deriveLiftMany = deriveLiftMany' <=< mapM reify
 
--- | Obtain Info values through a custom reification function. This is useful
+-- | Obtain 'Info' values through a custom reification function. This is useful
 -- when generating instances for datatypes that have not yet been declared.
 deriveLift' :: Info -> Q [Dec]
 deriveLift' = fmap (:[]) . deriveLiftOne
@@ -74,43 +102,17 @@ makeLift = makeLift' <=< reify
 
 -- | Like 'makeLift', but using a custom reification function.
 makeLift' :: Info -> Q Exp
-makeLift' i = withInfo i $ \_ n _ cons -> makeLiftOne n cons
+makeLift' i = withInfo i $ \_ n _ cons _ -> makeLiftOne n cons
 
 deriveLiftOne :: Info -> Q Dec
 deriveLiftOne i = withInfo i liftInstance
   where
-    liftInstance dcx n vs cons = do
-#if MIN_VERSION_template_haskell(2,9,0)
-      roles <- qReifyRoles n
-      -- Compute the set of phantom variables.
-      let phvars = catMaybes $
-            zipWith (\v role -> if role == PhantomR then Just v else Nothing)
-                    vs
-                    roles
-#else /* MIN_VERSION_template_haskell(2,9,0) */
-      let phvars = []
-#endif
-      instanceD (ctxt dcx phvars vs)
-                (conT ''Lift `appT` typ n (map fst vs))
+    liftInstance :: Cxt -> Name -> [(Name, Kind)] -> [Con] -> Maybe [Type] -> Q Dec
+    liftInstance dcx n vsk cons mbTys = do
+      (instanceCxt, instanceType) <- buildTypeInstance dcx n vsk mbTys
+      instanceD instanceCxt
+                instanceType
                 [funD 'lift [clause [] (normalB (makeLiftOne n cons)) []]]
-    typ n = foldl appT (conT n) . map varT
-    -- Only consider *-kinded type variables, because Lift instances cannot
-    -- meaningfully be given to types of other kinds. Further, filter out type
-    -- variables that are obviously phantom.
-    ctxt dcx phvars =
-        fmap (dcx ++) . cxt . concatMap liftPred . filter (`notElem` phvars)
-#if MIN_VERSION_template_haskell(2,10,0)
-    liftPred (v, StarT) = [conT ''Lift `appT` varT v]
-    liftPred (_, _) = []
-#elif MIN_VERSION_template_haskell(2,8,0)
-    liftPred (v, StarT) = [classP ''Lift [varT v]]
-    liftPred (_, _) = []
-#elif MIN_VERSION_template_haskell(2,4,0)
-    liftPred (v, StarK) = [classP ''Lift [varT v]]
-    liftPred (_, _) = []
-#else /* !(MIN_VERSION_template_haskell(2,4,0)) */
-    liftPred n = conT ''Lift `appT` varT n
-#endif
 
 makeLiftOne :: Name -> [Con] -> Q Exp
 makeLiftOne n cons = do
@@ -128,7 +130,7 @@ doCons (NormalC c sts) = do
     ns <- zipWithM (\_ i -> newName ('x':show (i :: Int))) sts [0..]
     let con = [| conE c |]
         args = [ liftVar n t | (n, (_, t)) <- zip ns sts ]
-        e = foldl (\e1 e2 -> [| appE $e1 $e2 |]) con args
+        e = foldl' (\e1 e2 -> [| appE $e1 $e2 |]) con args
     match (conP c (map varP ns)) (normalB e) []
 doCons (RecC c sts) = doCons $ NormalC c [(s, t) | (_, s, t) <- sts]
 doCons (InfixC sty1 c sty2) = do
@@ -162,35 +164,204 @@ liftVar varName (ConT tyName)
 liftVar varName _ = [| lift $(varE varName) |]
 
 withInfo :: Info
-#if MIN_VERSION_template_haskell(2,4,0)
-         -> (Cxt -> Name -> [(Name, Kind)] -> [Con] -> Q a)
-#else /* !(MIN_VERSION_template_haskell(2,4,0)) */
-         -> (Cxt -> Name -> [Name]         -> [Con] -> Q a)
-#endif
+         -> (Cxt -> Name -> [(Name, Kind)] -> [Con] -> Maybe [Type] -> Q a)
          -> Q a
 withInfo i f = case i of
     TyConI (DataD dcx n vsk cons _) ->
-        f dcx n (map unTyVarBndr vsk) cons
+        f dcx n (map unTyVarBndr vsk) cons Nothing
     TyConI (NewtypeD dcx n vsk con _) ->
-        f dcx n (map unTyVarBndr vsk) [con]
-    _ -> error (modName ++ ".deriveLift: unhandled: " ++ pprint i)
-  where
-#if MIN_VERSION_template_haskell(2,8,0)
-    unTyVarBndr (PlainTV v) = (v, StarT)
-    unTyVarBndr (KindedTV v k) = (v, k)
-#elif MIN_VERSION_template_haskell(2,4,0)
-    unTyVarBndr (PlainTV v) = (v, StarK)
-    unTyVarBndr (KindedTV v k) = (v, k)
-#else /* !(MIN_VERSION_template_haskell(2,4,0)) */
-    unTyVarBndr :: Name -> Name
-    unTyVarBndr v = v
+        f dcx n (map unTyVarBndr vsk) [con] Nothing
+#if MIN_VERSION_template_haskell(2,7,0)
+# if MIN_VERSION_template_haskell(2,11,0)
+    DataConI instName _ parentName   -> do
+# else
+    DataConI instName _ parentName _ -> do
+# endif
+      parentInfo <- reify parentName
+      case parentInfo of
+# if MIN_VERSION_template_haskell(2,11,0)
+        FamilyI (DataFamilyD _ vsk _) decs ->
+# else
+        FamilyI (FamilyD DataFam _ vsk _) decs ->
+# endif
+          let getConName :: Con -> Name
+              getConName (NormalC name _)  = name
+              getConName (RecC name _)     = name
+              getConName (InfixC _ name _) = name
+              getConName (ForallC _ _ con) = getConName con
+
+              instDec :: Maybe Dec
+              instDec = flip find decs $ \dec -> case dec of
+                DataInstD    _ _ _ cons _ -> any ((instName ==) . getConName) cons
+                NewtypeInstD _ _ _ con  _ -> instName == getConName con
+                _ -> error $ prefix ++ "Must be a data or newtype instance."
+          in case instDec of
+            Just (DataInstD    dcx _ instTys cons _) ->
+                f dcx parentName (map unTyVarBndr vsk) cons $ Just instTys
+            Just (NewtypeInstD dcx _ instTys con  _) ->
+                f dcx parentName (map unTyVarBndr vsk) [con] $ Just instTys
+            _ -> error $ prefix ++
+                    "Could not find data or newtype instance constructor."
+        _ -> error $ prefix ++ "Data constructor " ++ show instName ++
+               " is not from a data family instance constructor."
+# if MIN_VERSION_template_haskell(2,11,0)
+    FamilyI DataFamilyD{} _ ->
+# else
+    FamilyI (FamilyD DataFam _ _ _) _ ->
+# endif
+      error $ prefix ++
+        "Cannot use a data family name. Use a data family instance constructor instead."
 #endif
+    _ -> error (prefix ++ "unhandled: " ++ pprint i)
+  where
+    prefix = modName ++ ".deriveLift: "
+
+-- | Infer the context and instance head needed for a Lift instance.
+buildTypeInstance :: Cxt
+                  -- ^ The datatype context
+                  -> Name
+                  -- ^ The type constructor or data family name
+                  -> [(Name, Kind)]
+                  -- ^ The type variables from the data type/data family declaration
+                  -> Maybe [Type]
+                  -- ^ 'Just' the types used to instantiate a data family instance,
+                  -- or 'Nothing' if it's a plain data type
+                  -> Q (Q Cxt, Q Type)
+                  -- ^ The resulting 'Cxt' and 'Type' to use in a class instance
+-- Plain data type/newtype case
+buildTypeInstance dcx tyConName vsk Nothing = do
+    phvars <- computePhvars tyConName vsk
+    return (ctxt dcx phvars vsk, conT ''Lift `appT` instanceType)
+  where
+    instanceType :: Q Type
+    instanceType = typ tyConName $ map (varT . fst) vsk
+-- Data family instance case
+buildTypeInstance dcx dataFamName vsk (Just instTysAndKinds) = do
+    phvars <- computePhvars dataFamName vsk
+    return (ctxt dcx phvars lhsVs, conT ''Lift `appT` instanceType)
+  where
+    -- We need to make sure that type variables in the instance head which have
+    -- constraints aren't poly-kinded, e.g.,
+    --
+    -- @
+    -- instance Lift a => Lift (Foo (a :: k)) where
+    -- @
+    --
+    -- To do this, we remove every kind ascription (i.e., strip off every 'SigT').
+    instanceType :: Q Type
+    instanceType = typ dataFamName $ map (return . unSigT) rhsTypes
+
+    -- We need to mindful of an old GHC bug which causes kind variables appear in
+    -- @instTysAndKinds@ (as the name suggests) if (1) @PolyKinds@ is enabled, and
+    -- (2) either GHC 7.6 or 7.8 is being used (for more info, see
+    -- https://ghc.haskell.org/trac/ghc/ticket/9692).
+    --
+    -- Since Template Haskell doesn't seem to have a mechanism for detecting which
+    -- language extensions are enabled, we do the next-best thing by counting
+    -- the number of distinct kind variables in the data family declaration, and
+    -- then dropping that number of entries from @instTysAndKinds@
+    instTypes :: [Type]
+    instTypes =
+#if __GLASGOW_HASKELL__ >= 710 || !(MIN_VERSION_template_haskell(2,8,0))
+        instTysAndKinds
+#else
+        drop (Set.size . Set.unions $ map (distinctKindVars . snd) vsk)
+             instTysAndKinds
+
+    distinctKindVars :: Kind -> Set.Set Name
+    distinctKindVars (AppT k1 k2) = distinctKindVars k1 `Set.union` distinctKindVars k2
+    distinctKindVars (SigT k _)   = distinctKindVars k
+    distinctKindVars (VarT k)     = Set.singleton k
+    distinctKindVars _            = Set.empty
+#endif
+
+    lhsVs :: [(Name, Kind)]
+    lhsVs = map (uncurry replaceTyVarName)
+          . filter (isTyVar . snd)
+          $ zip vsk rhsTypes
+
+    -- In GHC 7.8, only the @Type@s up to the rightmost non-eta-reduced type variable
+    -- in @instTypes@ are provided (as a result of this bug:
+    -- https://ghc.haskell.org/trac/ghc/ticket/9692). To work around this, we borrow
+    -- some type variables from the data family instance declaration.
+    rhsTypes :: [Type]
+    rhsTypes =
+#if __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
+            instTypes ++ map (\(n, k) -> SigT (VarT n) k)
+                             (drop (length instTypes) vsk)
+#else
+            instTypes
+#endif
+
+-- | Is the given type a variable?
+isTyVar :: Type -> Bool
+isTyVar (VarT _)   = True
+isTyVar (SigT t _) = isTyVar t
+isTyVar _          = False
+
+-- | Replace the Name of a type variable with one from a Type (if the Type has a Name).
+replaceTyVarName :: (Name, Kind) -> Type -> (Name, Kind)
+replaceTyVarName nk     (SigT t _) = replaceTyVarName nk t
+replaceTyVarName (_, k) (VarT n)   = (n, k)
+replaceTyVarName nk     _          = nk
+
+-- | Peel off a kind signature from a Type (if it has one).
+unSigT :: Type -> Type
+unSigT (SigT t _) = t
+unSigT t          = t
 
 -- A type-restricted version of error that ensures makeLift always returns a
 -- value of type Q Exp, even when used on an empty datatype.
 errorQExp :: String -> Q Exp
 errorQExp = error
 {-# INLINE errorQExp #-}
+
+typ :: Name -> [Q Type] -> Q Type
+typ n = foldl' appT (conT n)
+
+-- Only consider *-kinded type variables, because Lift instances cannot
+-- meaningfully be given to types of other kinds. Further, filter out type
+-- variables that are obviously phantom.
+ctxt :: [Pred] -> [(Name, Kind)] -> [(Name, Kind)] -> Q Cxt
+ctxt dcx phvars =
+    fmap (dcx ++) . cxt . concatMap liftPred . filter (`notElem` phvars)
+  where
+#if MIN_VERSION_template_haskell(2,10,0)
+    liftPred (v, StarT) = [conT ''Lift `appT` varT v]
+    liftPred (_, _) = []
+#elif MIN_VERSION_template_haskell(2,8,0)
+    liftPred (v, StarT) = [classP ''Lift [varT v]]
+    liftPred (_, _) = []
+#elif MIN_VERSION_template_haskell(2,4,0)
+    liftPred (v, StarK) = [classP ''Lift [varT v]]
+    liftPred (_, _) = []
+#else /* !(MIN_VERSION_template_haskell(2,4,0)) */
+    liftPred n = conT ''Lift `appT` varT n
+#endif
+
+computePhvars :: Name -> [(Name, Kind)] -> Q [(Name, Kind)]
+#if MIN_VERSION_template_haskell(2,9,0)
+computePhvars n vsk = do
+    roles <- qReifyRoles n
+    -- Compute the set of phantom variables.
+    return $ catMaybes $
+        zipWith (\v role -> if role == PhantomR then Just v else Nothing)
+                vsk
+                roles
+#else /* MIN_VERSION_template_haskell(2,9,0) */
+computePhvars _ _ = return []
+#endif
+
+unTyVarBndr :: TyVarBndr -> (Name, Kind)
+#if MIN_VERSION_template_haskell(2,8,0)
+unTyVarBndr (PlainTV v) = (v, StarT)
+unTyVarBndr (KindedTV v k) = (v, k)
+#elif MIN_VERSION_template_haskell(2,4,0)
+unTyVarBndr (PlainTV v) = (v, StarK)
+unTyVarBndr (KindedTV v k) = (v, k)
+#else /* !(MIN_VERSION_template_haskell(2,4,0)) */
+unTyVarBndr v = v
+#endif
 
 instance Lift Name where
   lift (Name occName nameFlavour) = [| Name occName nameFlavour |]

--- a/t/Foo.hs
+++ b/t/Foo.hs
@@ -1,10 +1,20 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+#if MIN_VERSION_template_haskell(2,7,0)
+{-# LANGUAGE TypeFamilies #-}
+#endif
+
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
 module Foo where
 
 import GHC.Prim (Double#, Float#, Int#, Word#)
@@ -47,3 +57,20 @@ $(deriveLift ''Empty)
 $(deriveLift ''Unboxed)
 instance Lift (f (Fix f)) => Lift (Fix f) where
   lift = $(makeLift ''Fix)
+
+
+#if MIN_VERSION_template_haskell(2,7,0)
+data family DataFam
+# if __GLASGOW_HASKELL__ >= 706
+                    (a :: k)
+# else
+                     a
+# endif
+data    instance DataFam Int  = FamFoo Int
+                              | FamBar Int Int  deriving Show
+newtype instance DataFam Char = FamNewtype Char deriving Show
+
+$(deriveLift 'FamFoo)
+instance Lift (DataFam Char) where
+  lift = $(makeLift 'FamNewtype)
+#endif

--- a/t/Test.hs
+++ b/t/Test.hs
@@ -16,3 +16,7 @@ main = do print $( lift (Foo "str1" 'c') )
 #endif
                           1.0## 1.0# 1# 1##) )
           print $( lift (In { out = Nothing }) )
+#if MIN_VERSION_template_haskell(2,7,0)
+          print $( lift (FamBar 1 2) )
+          print $( lift (FamNewtype 'z') )
+#endif

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -24,6 +24,7 @@ Library
   Extensions:      CPP, TemplateHaskell, MagicHash, TypeSynonymInstances, FlexibleInstances
   Hs-Source-Dirs:  src
   Build-Depends:   base >= 3 && < 5,
+                   containers >= 0.1 && < 0.6,
                    ghc-prim
 
   ghc-options:     -Wall


### PR DESCRIPTION
`deriveLift` and `makeLift` can now derive for data family instances if you pass them the name of a data family instance's constructor. Note that this feature only works with GHC 7.4 and above, since that is when Template Haskell was given the ability to reify data family `Info`.

This fixes #17 once and for all.