### PR TITLE
cabal:  remove the upper bound on template haskell (GHC 8.4 compat)

### DIFF
--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -31,7 +31,7 @@ Library
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.13
+    Build-Depends: template-haskell >= 2.4
 
 Test-Suite test
   Type:             exitcode-stdio-1.0
@@ -46,4 +46,4 @@ Test-Suite test
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.13
+    Build-Depends: template-haskell >= 2.4


### PR DESCRIPTION
Tested to build on 8.0.1, 7.10.3 and 8.4-alpha1

I can re-add a relaxed bound, if you feel more like it..