### PR TITLE
* stack.yaml: Changed lts to 10.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-10.2
+resolver: lts-10.4
 packages:
 - '.'


### PR DESCRIPTION
When building Yesod with the old LTS the build fails. Not totally sure why, but It seems that this change helps with that, and the package itself is not harmed.