### PR TITLE
Add support for data families through th-abstraction

### DIFF
--- a/t/Test.hs
+++ b/t/Test.hs
@@ -16,3 +16,9 @@ main = do print $( lift (Foo "str1" 'c') )
 #endif
                           1.0## 1.0# 1# 1##) )
           print $( lift (In { out = Nothing }) )
+#if MIN_VERSION_template_haskell(2,7,0)
+          print $( lift (FamPrefix1 "str1" 'c') )
+          print $( lift (FamPrefix2 "str2") )
+          print $( lift (FamRec {famField = 'a'}) )
+          print $( lift ('a' :%%: 'b') )
+#endif

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -24,7 +24,8 @@ Library
   Extensions:      CPP, TemplateHaskell, MagicHash, TypeSynonymInstances, FlexibleInstances
   Hs-Source-Dirs:  src
   Build-Depends:   base >= 3 && < 5,
-                   ghc-prim
+                   ghc-prim,
+                   th-abstraction >= 0.2.3
 
   ghc-options:     -Wall
   if impl(ghc < 6.12)


### PR DESCRIPTION
This leverages th `th-abstraction` library to handle the dirty work of consolidating the differences between plain data types and data families. As an added bonus, it cleans up a good deal of code in `doCons`, `withInfo`, and `deriveLiftOne`.

I've added some test cases for data families, and ensured that they pass on GHCs 7.0 through 8.4.

Fixes #17.