### PR TITLE
th-lift.cabal: bump upper bound on TH

### DIFF
--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -32,7 +32,7 @@ Library
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.14
+    Build-Depends: template-haskell >= 2.4 && < 2.15
 
 Test-Suite test
   Type:             exitcode-stdio-1.0
@@ -47,4 +47,4 @@ Test-Suite test
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.14
+    Build-Depends: template-haskell >= 2.4 && < 2.15


### PR DESCRIPTION
This is needed to make it work with GHC 8.6.