### PR TITLE
Make deriveLift implement liftTyped on template-haskell-2.16+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8]
+## [0.8.1] - 2019-05-09
+
+* Support GHC 8.8/`template-haskell-2.15`.
+
+## [0.8] - 2019-04-26
 
 * Remove `Lift ()`, `Ratio`, `Identity` and `Const ()` instances.
   These are now provided in [`th-lift-instances` package](http://hackage.haskell.org/package/th-lift-instances)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [next] - ????-??-??
+
+* Support GHC 8.10/`template-haskell-2.16`.
+* Derive implementations of `liftTyped` (in addition to `lift`) when using
+  `template-haskell-2.16` or later.
+
 ## [0.8.1] - 2019-05-09
 
 * Support GHC 8.8/`template-haskell-2.15`.

--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -125,7 +125,11 @@ deriveLiftOne i = withInfo i liftInstance
 #endif
       instanceD (ctxt dcx phtys tys)
                 (conT ''Lift `appT` typ n tys)
-                [funD 'lift [clause [] (normalB (makeLiftOne n cons)) []]]
+                [ funD 'lift [clause [] (normalB (makeLiftOne n cons)) []]
+#if MIN_VERSION_template_haskell(2,16,0)
+                , funD 'liftTyped [clause [] (normalB [| unsafeTExpCoerce . lift |]) []]
+#endif
+                ]
     typ n = foldl appT (conT n) . map unKind
     -- Only consider *-kinded type variables, because Lift instances cannot
     -- meaningfully be given to types of other kinds. Further, filter out type
@@ -232,16 +236,28 @@ errorQExp = error
 
 instance Lift Name where
   lift (Name occName nameFlavour) = [| Name occName nameFlavour |]
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif
 
 #if MIN_VERSION_template_haskell(2,4,0)
 instance Lift OccName where
   lift n = [| mkOccName |] `appE` lift (occString n)
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif
 
 instance Lift PkgName where
   lift n = [| mkPkgName |] `appE` lift (pkgString n)
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif
 
 instance Lift ModName where
   lift n = [| mkModName |] `appE` lift (modString n)
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif
 #endif /* MIN_VERSION_template_haskell(2,4,0) */
 
 instance Lift NameFlavour where
@@ -258,8 +274,14 @@ instance Lift NameFlavour where
 #endif /* __GLASGOW_HASKELL__ < 710 */
   lift (NameG nameSpace' pkgName modnam)
    = [| NameG nameSpace' pkgName modnam |]
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif
 
 instance Lift NameSpace where
   lift VarName = [| VarName |]
   lift DataName = [| DataName |]
   lift TcClsName = [| TcClsName |]
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = unsafeTExpCoerce . lift
+#endif

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -35,7 +35,7 @@ Library
   Build-Depends:    base              >= 4.3  && < 5,
                     ghc-prim,
                     th-abstraction   >= 0.2.3 && < 0.4,
-                    template-haskell >= 2.4   && < 2.16
+                    template-haskell >= 2.4   && < 2.17
 
 Test-Suite test
   Default-Language: Haskell2010


### PR DESCRIPTION
`template-haskell-2.16.0.0` adds a `liftTyped` method to `Lift`, which is like `lift` but returning `Q (TExp t)` instead of `Q Exp`. `liftTyped` does not have a default implementation in terms of `lift`, so using `deriveLift` with `template-haskell-2.16` at the moment results in warnings like these:

```
t/Foo.hs:58:3: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift (Foo a b)’
   |
58 | $(deriveLift ''Foo)
   |   ^^^^^^^^^^^^^^^^
```

This patch removes these warnings by having `deriveLift` implement `liftTyped` in addition to `lift`. The implementation I chose is based off of the general approach taken by `Language.Haskell.TH.Syntax`, such as in this example: https://gitlab.haskell.org/ghc/ghc/blob/4898df1cc25132dc9e2599d4fa4e1bbc9423cda5/libraries/template-haskell/Language/Haskell/TH/Syntax.hs#L716